### PR TITLE
Add Gradio Stable Diffusion XL demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Python
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -90,3 +90,17 @@ npx bmad-method install
 ## I want to use a custom domain - is that possible?
 
 We don't support custom domains (yet). If you want to deploy your project under your own domain then we recommend using Netlify. Visit our docs for more details: [Custom domains](https://docs.lovable.dev/tips-tricks/custom-domain/)
+
+## Stable Diffusion XL Gradio demo
+
+This repository now includes a simple [Gradio](https://gradio.app) interface built with the Stable Diffusion XL model from Hugging Face.
+
+### Running the demo
+
+```sh
+pip install -r requirements.txt
+export HF_TOKEN=<your_huggingface_token>
+python sdxl_gradio_app.py
+```
+
+Open the printed URL in your browser and enter a prompt to generate an image.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+gradio
+diffusers
+transformers
+accelerate
+torch
+safetensors

--- a/sdxl_gradio_app.py
+++ b/sdxl_gradio_app.py
@@ -1,0 +1,44 @@
+import os
+
+import torch
+from diffusers import DiffusionPipeline
+import gradio as gr
+
+MODEL_ID = "stabilityai/stable-diffusion-xl-base-1.0"
+
+def load_pipeline():
+    """Load the Stable Diffusion XL pipeline."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch_dtype = torch.float16 if device == "cuda" else torch.float32
+    kwargs = {
+        "torch_dtype": torch_dtype,
+        "use_safetensors": True,
+    }
+    if device == "cuda":
+        kwargs["variant"] = "fp16"
+    token = os.getenv("HF_TOKEN")
+    if token:
+        kwargs["use_auth_token"] = token
+    pipe = DiffusionPipeline.from_pretrained(MODEL_ID, **kwargs)
+    pipe.to(device)
+    return pipe
+
+PIPELINE = load_pipeline()
+
+
+def generate(prompt: str):
+    """Generate an image from the given prompt."""
+    image = PIPELINE(prompt).images[0]
+    return image
+
+
+interface = gr.Interface(
+    fn=generate,
+    inputs=gr.Textbox(label="Prompt"),
+    outputs=gr.Image(label="Generated image"),
+    title="Stable Diffusion XL",
+    description="Generate images using the Stable Diffusion XL model from Hugging Face.",
+)
+
+if __name__ == "__main__":
+    interface.launch()


### PR DESCRIPTION
## Summary
- Add Gradio app that loads Stable Diffusion XL via Hugging Face diffusers
- Document how to run the demo and list Python dependencies
- Load HF token from `HF_TOKEN` env var and ignore Python cache files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint errors in existing files)*
- `python -m py_compile sdxl_gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68996ba9c9508325a34cf3c4bed4e0a6